### PR TITLE
chore: enabling all codeowners as default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Add all team members as default reviewers for all files
+* @ckrook @mistermalm @theJohnnyMe @EmelieLitwin @nathalielindqvist @Lunkan89 @timrombergjakobsson


### PR DESCRIPTION
This adds a CODEOWNERS file that automatically adds all people listed in the file as reviewers on every pr. 