### PR TITLE
chore(workflow): create workflow to check and bump tegel version

### DIFF
--- a/.github/workflows/update-tegel.yml
+++ b/.github/workflows/update-tegel.yml
@@ -1,0 +1,76 @@
+name: Update Tegel Dependency
+
+on:
+  schedule:
+    - cron: '0 14 * * THU'
+  workflow_dispatch: # Allows manual trigger from GitHub UI
+
+jobs:
+  update-tegel:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Get latest stable Tegel version from npm
+        id: tegel_version
+        run: |
+          LATEST=$(npm view @scania/tegel-angular-17 dist-tags.latest)
+          echo "latest=$LATEST" >> $GITHUB_OUTPUT
+
+      - name: Get current Tegel version from package.json
+        id: current_version
+        run: |
+          CURRENT=$(node -p "require('./package.json').dependencies['@scania/tegel-angular-17']")
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+
+      - name: Compare versions
+        id: compare
+        run: |
+          LATEST="${{ steps.tegel_version.outputs.latest }}"
+          CURRENT="${{ steps.current_version.outputs.current }}"
+          if [ "$LATEST" = "$CURRENT" ]; then
+            echo "up_to_date=true" >> $GITHUB_OUTPUT
+            echo "Tegel is already up to date ($CURRENT)"
+          else
+            echo "up_to_date=false" >> $GITHUB_OUTPUT
+            echo "Update available: $CURRENT → $LATEST"
+          fi
+
+      - name: Update package.json with exact version
+        if: steps.compare.outputs.up_to_date == 'false'
+        run: |
+          sed -i 's|"@scania/tegel-angular-17": "\^?[^"]*"|"@scania/tegel-angular-17": "${{ steps.tegel_version.outputs.latest }}"|' package.json
+
+      - name: Install dependencies to update package-lock.json
+        if: steps.compare.outputs.up_to_date == 'false'
+        run: npm install --package-lock-only
+
+      - name: Open Pull Request
+        if: steps.compare.outputs.up_to_date == 'false'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/update-tegel-${{ steps.tegel_version.outputs.latest }}
+          commit-message: 'chore: update tegel to ${{ steps.tegel_version.outputs.latest }}'
+          title: 'chore: update @scania/tegel-angular-17 ${{ steps.current_version.outputs.current }} → ${{ steps.tegel_version.outputs.latest }}'
+          body: |
+            ## Tegel dependency update
+
+            | | Version |
+            |---|---|
+            | **Before** | `${{ steps.current_version.outputs.current }}` |
+            | **After** | `${{ steps.tegel_version.outputs.latest }}` |
+
+            This PR was opened automatically by the update-tegel workflow.
+          base: main
+          labels: dependencies


### PR DESCRIPTION
## **Describe pull-request**  
This PR creates an automation to check and bump the `tegel-angular-17` version every Thursday at 14:00.

For now the resulting PR of the workflow requires a manual approval, but the goal is to automate it after a few successful executions.

## **Issue Linking:**  
- **No issue:** Falls in the continuous improvements epic

## **How to test**  
1. Approve this PR 😅 
2. This Thursday, during the afternoon, check that the workflow has ran and no PRs were open (since there was no Tegel release this week)
3. Next Thursday, during the afternoon (and after the release), check the workflow and verify that a PR has been opened with the new tegel version. 
4. Approve the PR and profit 🤑 
  
