### PR TITLE
test: 1.52.0-var-work-beta.0 — link/breadcrumbs/divider/footer migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-angular-17": "1.51.0-var-work-beta.7",
+        "@scania/tegel-angular-17": "1.52.0-var-work-beta.0",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/angular-table": "^8.19.2",
         "ag-grid-angular": "^31.3.2",
@@ -35,7 +35,7 @@
         "jasmine-core": "~4.5.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.1.0",
-        "karma-coverage": "~2.2.0",
+        "karma-coverage": "~  2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
         "typescript": "~5.5.3"
@@ -4047,9 +4047,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
       "cpu": [
         "arm64"
       ],
@@ -4061,9 +4061,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
       "cpu": [
         "x64"
       ],
@@ -4131,9 +4131,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
       "cpu": [
         "loong64"
       ],
@@ -4145,9 +4145,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
       ],
@@ -4173,9 +4173,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
       "cpu": [
         "ppc64"
       ],
@@ -4187,9 +4187,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
       ],
@@ -4215,9 +4215,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
       ],
@@ -4271,9 +4271,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
       "cpu": [
         "x64"
       ],
@@ -4285,9 +4285,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
       "cpu": [
         "arm64"
       ],
@@ -4327,9 +4327,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
       "cpu": [
         "x64"
       ],
@@ -4355,9 +4355,9 @@
       ]
     },
     "node_modules/@scania/tegel": {
-      "version": "1.51.0-var-work-beta.7",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.7.tgz",
-      "integrity": "sha512-ZnP1qCa0lUKP81SJjM8kjcGinn2FAUlf6Ox5bHMLD/c7yfcXIrRQAlYDsMsJIGqU5J7RvoDnmJZseZHhIxnw0A==",
+      "version": "1.52.0-var-work-beta.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.52.0-var-work-beta.0.tgz",
+      "integrity": "sha512-rbMvQ51fB4uoy+2MZbFDL5lCilpAn3xZpUHZg1sAg+pGzOHylEkGMXjZUaBU+Blpv0RPMdVIgfXm2a1Mi5Sh6Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4371,16 +4371,16 @@
       }
     },
     "node_modules/@scania/tegel-angular-17": {
-      "version": "1.51.0-var-work-beta.7",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.7.tgz",
-      "integrity": "sha512-SgLToJM4QfywHFvAVtQ4laW2z4zfRP7Zv+xPDUk/DYofjTUmauoUdBGJfXzok7WP437pY+5WyrvAKGsd+vl4eg==",
+      "version": "1.52.0-var-work-beta.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.52.0-var-work-beta.0.tgz",
+      "integrity": "sha512-/12tNQLakdwKkbt2kuanWLACfxr+Atp8U8GLUdgTAtRCLHTbc4l88ddNvA4drbLPHF6UPFCOH9nPhvLwioqW9g==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">=17.0.0",
         "@angular/core": ">=17.0.0",
-        "@scania/tegel": "1.51.0-var-work-beta.7"
+        "@scania/tegel": "1.52.0-var-work-beta.0"
       }
     },
     "node_modules/@scania/tegel-styles": {
@@ -4802,9 +4802,9 @@
       }
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
       "cpu": [
         "arm"
       ],
@@ -4816,9 +4816,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
       "cpu": [
         "arm64"
       ],
@@ -4830,9 +4830,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
       "cpu": [
         "arm64"
       ],
@@ -4844,9 +4844,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
       "cpu": [
         "x64"
       ],
@@ -4858,9 +4858,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
       "cpu": [
         "arm"
       ],
@@ -4872,9 +4872,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
       ],
@@ -4886,9 +4886,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
       "cpu": [
         "arm64"
       ],
@@ -4900,9 +4900,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
       ],
@@ -4914,9 +4914,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
       "cpu": [
         "riscv64"
       ],
@@ -4928,9 +4928,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
       "cpu": [
         "s390x"
       ],
@@ -4942,9 +4942,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
       ],
@@ -4956,9 +4956,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
       ],
@@ -4970,9 +4970,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
       "cpu": [
         "arm64"
       ],
@@ -4984,9 +4984,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
       "cpu": [
         "ia32"
       ],
@@ -4998,9 +4998,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
       "cpu": [
         "x64"
       ],
@@ -5103,9 +5103,9 @@
       }
     },
     "node_modules/@scania/tegel/node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5119,31 +5119,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-angular-17": "1.51.0-var-work-beta.5",
+        "@scania/tegel-angular-17": "1.51.0-var-work-beta.6",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/angular-table": "^8.19.2",
         "ag-grid-angular": "^31.3.2",
@@ -4355,9 +4355,9 @@
       ]
     },
     "node_modules/@scania/tegel": {
-      "version": "1.51.0-var-work-beta.5",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.5.tgz",
-      "integrity": "sha512-1OhbW2I9cPxqn40Ssrg1uI6LRojWzQej4Wtgroz5ltX+vyU1kxBv4i4V2aP2lXLOzK/h6eHKlY1l4uyG6SpSFA==",
+      "version": "1.51.0-var-work-beta.6",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.6.tgz",
+      "integrity": "sha512-l+JSpXmyvtXZ98654f/2k/JhQ8ZBwwkuXtl/BqZsB5gpEWzPNLdrNPF/AVGigi8eVRkx1/OSh5X1xk2y6O6ysA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4371,16 +4371,16 @@
       }
     },
     "node_modules/@scania/tegel-angular-17": {
-      "version": "1.51.0-var-work-beta.5",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.5.tgz",
-      "integrity": "sha512-iAoWGsLf53mhXxnTxuPDwh4Yzj7xt2B6ig7J6sc41V27Wr+k5V1FR4ekPRlU9iQzwtzHzQJMoJm91WRJqXSKAA==",
+      "version": "1.51.0-var-work-beta.6",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.6.tgz",
+      "integrity": "sha512-o1Culqq+uY2QNvfax1WhdbLYdr5jzwYpeQ9wv5fTCJVLwhxKVq4tSbsjpw4LbBM77ByaknBgEHWCnxsCJ5hEGQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">=17.0.0",
         "@angular/core": ">=17.0.0",
-        "@scania/tegel": "1.51.0-var-work-beta.5"
+        "@scania/tegel": "1.51.0-var-work-beta.6"
       }
     },
     "node_modules/@scania/tegel-styles": {
@@ -5074,9 +5074,9 @@
       }
     },
     "node_modules/@scania/tegel/node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-angular-17": "1.51.0-var-work-beta.4",
+        "@scania/tegel-angular-17": "1.51.0-var-work-beta.5",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/angular-table": "^8.19.2",
         "ag-grid-angular": "^31.3.2",
@@ -4355,9 +4355,9 @@
       ]
     },
     "node_modules/@scania/tegel": {
-      "version": "1.51.0-var-work-beta.4",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.4.tgz",
-      "integrity": "sha512-SIrEHpCgkytPpvzI8zUUNBFhymcCJd8Ju0P7Pmw8GLDX1ENgtDIHbivUNYgnOIJ8fHvMnpjmoKfFYgwTBCUamg==",
+      "version": "1.51.0-var-work-beta.5",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.5.tgz",
+      "integrity": "sha512-1OhbW2I9cPxqn40Ssrg1uI6LRojWzQej4Wtgroz5ltX+vyU1kxBv4i4V2aP2lXLOzK/h6eHKlY1l4uyG6SpSFA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4371,16 +4371,16 @@
       }
     },
     "node_modules/@scania/tegel-angular-17": {
-      "version": "1.51.0-var-work-beta.4",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.4.tgz",
-      "integrity": "sha512-z4XaGaiM9TuOrJlChZXNQyqBb0nJKBzTB1Jhm05E1HOGZn6Jf6oIDMIBrTXtgPWYFFPH0Bfl7ay5LYJTDbFhyg==",
+      "version": "1.51.0-var-work-beta.5",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.5.tgz",
+      "integrity": "sha512-iAoWGsLf53mhXxnTxuPDwh4Yzj7xt2B6ig7J6sc41V27Wr+k5V1FR4ekPRlU9iQzwtzHzQJMoJm91WRJqXSKAA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">=17.0.0",
         "@angular/core": ">=17.0.0",
-        "@scania/tegel": "1.51.0-var-work-beta.4"
+        "@scania/tegel": "1.51.0-var-work-beta.5"
       }
     },
     "node_modules/@scania/tegel-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-angular-17": "1.51.0-var-work-beta.6",
+        "@scania/tegel-angular-17": "1.51.0-var-work-beta.7",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/angular-table": "^8.19.2",
         "ag-grid-angular": "^31.3.2",
@@ -4355,9 +4355,9 @@
       ]
     },
     "node_modules/@scania/tegel": {
-      "version": "1.51.0-var-work-beta.6",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.6.tgz",
-      "integrity": "sha512-l+JSpXmyvtXZ98654f/2k/JhQ8ZBwwkuXtl/BqZsB5gpEWzPNLdrNPF/AVGigi8eVRkx1/OSh5X1xk2y6O6ysA==",
+      "version": "1.51.0-var-work-beta.7",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.7.tgz",
+      "integrity": "sha512-ZnP1qCa0lUKP81SJjM8kjcGinn2FAUlf6Ox5bHMLD/c7yfcXIrRQAlYDsMsJIGqU5J7RvoDnmJZseZHhIxnw0A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4371,16 +4371,16 @@
       }
     },
     "node_modules/@scania/tegel-angular-17": {
-      "version": "1.51.0-var-work-beta.6",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.6.tgz",
-      "integrity": "sha512-o1Culqq+uY2QNvfax1WhdbLYdr5jzwYpeQ9wv5fTCJVLwhxKVq4tSbsjpw4LbBM77ByaknBgEHWCnxsCJ5hEGQ==",
+      "version": "1.51.0-var-work-beta.7",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.7.tgz",
+      "integrity": "sha512-SgLToJM4QfywHFvAVtQ4laW2z4zfRP7Zv+xPDUk/DYofjTUmauoUdBGJfXzok7WP437pY+5WyrvAKGsd+vl4eg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">=17.0.0",
         "@angular/core": ">=17.0.0",
-        "@scania/tegel": "1.51.0-var-work-beta.6"
+        "@scania/tegel": "1.51.0-var-work-beta.7"
       }
     },
     "node_modules/@scania/tegel-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-angular-17": "1.51.0-var-work-beta.2",
+        "@scania/tegel-angular-17": "1.51.0-var-work-beta.1",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/angular-table": "^8.19.2",
         "ag-grid-angular": "^31.3.2",
@@ -4355,9 +4355,9 @@
       ]
     },
     "node_modules/@scania/tegel": {
-      "version": "1.51.0-var-work-beta.2",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.2.tgz",
-      "integrity": "sha512-XWoRDxIQ0H34kTHM/XmelYKtw5+8lG1r0SKbPNwSLN9QbGERF82XAqNUx30ccfnbPpGKpZnRTHPajvWiJodMEA==",
+      "version": "1.51.0-var-work-beta.1",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.1.tgz",
+      "integrity": "sha512-ooMGXo/38hHvkRmYzXtDaMASNzWUmsZ1n9UDsTwDDYJ6P3p+QsDcQNoM2CtI/J7O5XUlVRThVv0PXK3dbVsuAw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4371,16 +4371,16 @@
       }
     },
     "node_modules/@scania/tegel-angular-17": {
-      "version": "1.51.0-var-work-beta.2",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.2.tgz",
-      "integrity": "sha512-3gcyaZdY5PuMvgBl9noI5LxL5jAzku4ykZ+cRzWCzWz1W/B5l7b5iq+EJqyswz/piPY3oIiDV6DA4BdIKcV4Dg==",
+      "version": "1.51.0-var-work-beta.1",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.1.tgz",
+      "integrity": "sha512-k64uFNmrCa8J9psJDIM/6S3GB0SwqEPsc3w/qH/SaVxbDBoeHHu5XUqLH7D5SM0mwpqJ94T0C2gn1UIBvzyibA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">=17.0.0",
         "@angular/core": ">=17.0.0",
-        "@scania/tegel": "1.51.0-var-work-beta.2"
+        "@scania/tegel": "1.51.0-var-work-beta.1"
       }
     },
     "node_modules/@scania/tegel-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-angular-17": "1.51.0",
+        "@scania/tegel-angular-17": "1.51.0-var-work-beta.2",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/angular-table": "^8.19.2",
         "ag-grid-angular": "^31.3.2",
@@ -4137,9 +4137,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4153,9 +4150,6 @@
       "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4185,9 +4179,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4201,9 +4192,6 @@
       "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4232,9 +4220,6 @@
       "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4370,9 +4355,9 @@
       ]
     },
     "node_modules/@scania/tegel": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0.tgz",
-      "integrity": "sha512-wChnv7mnY0aLWxMcCKPmcp2x81z6zzv0wchQTXHjf2YBu9AQRmZD2va+ldD+etO/wXc5jrGtHkpudcn/T9YKxg==",
+      "version": "1.51.0-var-work-beta.2",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.2.tgz",
+      "integrity": "sha512-XWoRDxIQ0H34kTHM/XmelYKtw5+8lG1r0SKbPNwSLN9QbGERF82XAqNUx30ccfnbPpGKpZnRTHPajvWiJodMEA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4386,16 +4371,16 @@
       }
     },
     "node_modules/@scania/tegel-angular-17": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0.tgz",
-      "integrity": "sha512-bBiwghjHA7aCZDSN0Zj9rAdKs3HpqhQcSJef+9/aUbxnYtqLsS3SEorshT88E9OWB7Pbfn2hGbEQ1f/re8YJjw==",
+      "version": "1.51.0-var-work-beta.2",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.2.tgz",
+      "integrity": "sha512-3gcyaZdY5PuMvgBl9noI5LxL5jAzku4ykZ+cRzWCzWz1W/B5l7b5iq+EJqyswz/piPY3oIiDV6DA4BdIKcV4Dg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">=17.0.0",
         "@angular/core": ">=17.0.0",
-        "@scania/tegel": "^1.51.0"
+        "@scania/tegel": "1.51.0-var-work-beta.2"
       }
     },
     "node_modules/@scania/tegel-styles": {
@@ -4879,9 +4864,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4895,9 +4877,6 @@
       "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4913,9 +4892,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4929,9 +4905,6 @@
       "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4947,9 +4920,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4963,9 +4933,6 @@
       "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4981,9 +4948,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4997,9 +4961,6 @@
       "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5437,9 +5398,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5453,9 +5411,6 @@
       "integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5471,9 +5426,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5487,9 +5439,6 @@
       "integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7919,6 +7868,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8799,7 +8749,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/handle-thing": {
@@ -9163,6 +9113,7 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
       "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -10163,6 +10114,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10177,6 +10129,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -10190,6 +10143,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -10200,6 +10154,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
@@ -11111,6 +11066,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
       "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11128,6 +11084,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12003,6 +11960,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -12267,6 +12225,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -12822,7 +12781,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -12888,6 +12847,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-angular-17": "1.51.0-var-work-beta.1",
+        "@scania/tegel-angular-17": "1.51.0-var-work-beta.4",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/angular-table": "^8.19.2",
         "ag-grid-angular": "^31.3.2",
@@ -4355,9 +4355,9 @@
       ]
     },
     "node_modules/@scania/tegel": {
-      "version": "1.51.0-var-work-beta.1",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.1.tgz",
-      "integrity": "sha512-ooMGXo/38hHvkRmYzXtDaMASNzWUmsZ1n9UDsTwDDYJ6P3p+QsDcQNoM2CtI/J7O5XUlVRThVv0PXK3dbVsuAw==",
+      "version": "1.51.0-var-work-beta.4",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.4.tgz",
+      "integrity": "sha512-SIrEHpCgkytPpvzI8zUUNBFhymcCJd8Ju0P7Pmw8GLDX1ENgtDIHbivUNYgnOIJ8fHvMnpjmoKfFYgwTBCUamg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4371,16 +4371,16 @@
       }
     },
     "node_modules/@scania/tegel-angular-17": {
-      "version": "1.51.0-var-work-beta.1",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.1.tgz",
-      "integrity": "sha512-k64uFNmrCa8J9psJDIM/6S3GB0SwqEPsc3w/qH/SaVxbDBoeHHu5XUqLH7D5SM0mwpqJ94T0C2gn1UIBvzyibA==",
+      "version": "1.51.0-var-work-beta.4",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.4.tgz",
+      "integrity": "sha512-z4XaGaiM9TuOrJlChZXNQyqBb0nJKBzTB1Jhm05E1HOGZn6Jf6oIDMIBrTXtgPWYFFPH0Bfl7ay5LYJTDbFhyg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">=17.0.0",
         "@angular/core": ">=17.0.0",
-        "@scania/tegel": "1.51.0-var-work-beta.1"
+        "@scania/tegel": "1.51.0-var-work-beta.4"
       }
     },
     "node_modules/@scania/tegel-styles": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-angular-17": "1.51.0-var-work-beta.4",
+    "@scania/tegel-angular-17": "1.51.0-var-work-beta.5",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/angular-table": "^8.19.2",
     "ag-grid-angular": "^31.3.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-angular-17": "1.51.0-var-work-beta.6",
+    "@scania/tegel-angular-17": "1.51.0-var-work-beta.7",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/angular-table": "^8.19.2",
     "ag-grid-angular": "^31.3.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-angular-17": "1.51.0",
+    "@scania/tegel-angular-17": "1.51.0-var-work-beta.2",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/angular-table": "^8.19.2",
     "ag-grid-angular": "^31.3.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-angular-17": "1.51.0-var-work-beta.7",
+    "@scania/tegel-angular-17": "1.52.0-var-work-beta.0",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/angular-table": "^8.19.2",
     "ag-grid-angular": "^31.3.2",
@@ -38,7 +38,7 @@
     "jasmine-core": "~4.5.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.1.0",
-    "karma-coverage": "~2.2.0",
+    "karma-coverage": "~  2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
     "typescript": "~5.5.3"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-angular-17": "1.51.0-var-work-beta.5",
+    "@scania/tegel-angular-17": "1.51.0-var-work-beta.6",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/angular-table": "^8.19.2",
     "ag-grid-angular": "^31.3.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-angular-17": "1.51.0-var-work-beta.1",
+    "@scania/tegel-angular-17": "1.51.0-var-work-beta.4",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/angular-table": "^8.19.2",
     "ag-grid-angular": "^31.3.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-angular-17": "1.51.0-var-work-beta.2",
+    "@scania/tegel-angular-17": "1.51.0-var-work-beta.1",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/angular-table": "^8.19.2",
     "ag-grid-angular": "^31.3.2",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -211,6 +211,7 @@
             <app-mode-variant-switcher
               (modeVariantToggle)="handleModeVariantToggle()"
             ></app-mode-variant-switcher>
+            <app-brand-switcher></app-brand-switcher>
           </div>
           <div class="tds-u-h-100 tds-u-flex tds-u-flex-dir-col">
             <nav-breadcrumbs *ngIf="!is404page"></nav-breadcrumbs>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,6 +9,7 @@ import {
 } from "@angular/router";
 import { ModeSwitcherComponent } from "./mode-switcher/mode-switcher.component";
 import { ModeVariantSwitcherComponent } from "./mode-variant-switcher/mode-variant-switcher.component";
+import { BrandSwitcherComponent } from "./brand-switcher/brand-switcher.component";
 import BreadcrumbsComponent from "./navigation/breadcrumbs/breadcrumbs.component";
 import { BannerComponent } from "@components/banner/banner.component";
 import { UserStoreService } from "./services/user-store.service";
@@ -30,6 +31,7 @@ import { TegelModule } from "@scania/tegel-angular-17";
     BreadcrumbsComponent,
     ModeSwitcherComponent,
     ModeVariantSwitcherComponent,
+    BrandSwitcherComponent,
     CommonModule,
     TegelModule,
   ],

--- a/src/app/brand-switcher/brand-switcher.component.html
+++ b/src/app/brand-switcher/brand-switcher.component.html
@@ -1,0 +1,7 @@
+<tds-toggle
+  (tdsToggle)="toggleBrand()"
+  headline="Brand"
+  size="sm"
+>
+  <div slot="label">{{ labelText }}</div>
+</tds-toggle>

--- a/src/app/brand-switcher/brand-switcher.component.ts
+++ b/src/app/brand-switcher/brand-switcher.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit } from "@angular/core";
+import { TegelModule } from "@scania/tegel-angular-17";
+
+@Component({
+  selector: "app-brand-switcher",
+  templateUrl: "./brand-switcher.component.html",
+  standalone: true,
+  imports: [TegelModule],
+})
+export class BrandSwitcherComponent implements OnInit {
+  brand: "scania" | "traton" = "scania";
+  labelText: "Scania" | "Traton" = "Scania";
+
+  ngOnInit(): void {
+    this.applyBrand();
+  }
+
+  toggleBrand() {
+    this.brand = this.brand === "scania" ? "traton" : "scania";
+    this.labelText = this.brand === "scania" ? "Scania" : "Traton";
+    this.applyBrand();
+  }
+
+  private applyBrand() {
+    const body = document.body;
+    body.classList.remove("scania", "traton");
+    body.classList.add(this.brand);
+  }
+}

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -1,7 +1,7 @@
 <h3>About this page</h3>
 <p>
   This page is a testing ground for the variable migration in
-  <b>&#64;scania/tegel-angular-17&#64;1.51.0-var-work-beta.4</b>. It showcases the
+  <b>&#64;scania/tegel-angular-17&#64;1.51.0-var-work-beta.5</b>. It showcases the
   affected components (Link, Breadcrumbs, Divider, Footer) in multiple states
   so every edge case is testable. Use the Brand toggle in the top-right corner
   to switch between the Scania and Traton brands.

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -1,7 +1,7 @@
 <h3>About this page</h3>
 <p>
   This page is a testing ground for the variable migration in
-  <b>&#64;scania/tegel-angular-17&#64;1.51.0-var-work-beta.1</b>. It showcases the
+  <b>&#64;scania/tegel-angular-17&#64;1.51.0-var-work-beta.4</b>. It showcases the
   affected components (Link, Breadcrumbs, Divider, Footer) in multiple states
   so every edge case is testable. Use the Brand toggle in the top-right corner
   to switch between the Scania and Traton brands.

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -1,7 +1,7 @@
 <h3>About this page</h3>
 <p>
   This page is a testing ground for the variable migration in
-  <b>&#64;scania/tegel-angular-17&#64;1.51.0-var-work-beta.5</b>. It showcases the
+  <b>&#64;scania/tegel-angular-17&#64;1.51.0-var-work-beta.7</b>. It showcases the
   affected components (Link, Breadcrumbs, Divider, Footer) in multiple states
   so every edge case is testable. Use the Brand toggle in the top-right corner
   to switch between the Scania and Traton brands.

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -1,7 +1,7 @@
 <h3>About this page</h3>
 <p>
   This page is a testing ground for the variable migration in
-  <b>&#64;scania/tegel-angular-17&#64;1.51.0-var-work-beta.7</b>. It showcases the
+  <b>&#64;scania/tegel-angular-17&#64;1.52.0-var-work-beta.0</b>. It showcases the
   affected components (Link, Breadcrumbs, Divider, Footer) in multiple states
   so every edge case is testable. Use the Brand toggle in the top-right corner
   to switch between the Scania and Traton brands.

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -1,7 +1,7 @@
 <h3>About this page</h3>
 <p>
   This page is a testing ground for the variable migration in
-  <b>&#64;scania/tegel-angular-17&#64;1.51.0-var-work-beta.2</b>. It showcases the
+  <b>&#64;scania/tegel-angular-17&#64;1.51.0-var-work-beta.1</b>. It showcases the
   affected components (Link, Breadcrumbs, Divider, Footer) in multiple states
   so every edge case is testable. Use the Brand toggle in the top-right corner
   to switch between the Scania and Traton brands.

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -123,34 +123,50 @@
 <section class="tds-u-pt3">
   <h4 class="tds-headline-03">Divider</h4>
 
+  <!-- Horizontal — all variants -->
   <div class="tds-u-pt1">
-    <p class="tds-detail-02 tds-u-pb1">Default horizontal divider</p>
+    <p class="tds-detail-02 tds-u-pb1">Horizontal — subtle (default)</p>
     <tds-divider></tds-divider>
   </div>
 
   <div class="tds-u-pt2">
-    <p class="tds-detail-02 tds-u-pb1">Light horizontal divider</p>
-    <tds-divider type="light"></tds-divider>
+    <p class="tds-detail-02 tds-u-pb1">Horizontal — discrete</p>
+    <tds-divider variant="discrete"></tds-divider>
   </div>
 
   <div class="tds-u-pt2">
-    <p class="tds-detail-02 tds-u-pb1">Strong horizontal divider</p>
-    <tds-divider type="strong"></tds-divider>
+    <p class="tds-detail-02 tds-u-pb1">Horizontal — soft</p>
+    <tds-divider variant="soft"></tds-divider>
   </div>
 
   <div class="tds-u-pt2">
-    <p class="tds-detail-02 tds-u-pb1">Vertical divider (default / light / strong)</p>
+    <p class="tds-detail-02 tds-u-pb1">Horizontal — defined</p>
+    <tds-divider variant="defined"></tds-divider>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Horizontal — dark-blue</p>
+    <tds-divider variant="dark-blue"></tds-divider>
+  </div>
+
+  <!-- Vertical — all variants -->
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Vertical — all variants</p>
     <div class="tds-u-flex tds-u-gap2" style="height: 48px; align-items: center;">
-      <span>Left</span>
+      <span>subtle</span>
       <tds-divider orientation="vertical"></tds-divider>
-      <span>Middle</span>
-      <tds-divider orientation="vertical" type="light"></tds-divider>
-      <span>After light</span>
-      <tds-divider orientation="vertical" type="strong"></tds-divider>
-      <span>Right</span>
+      <span>discrete</span>
+      <tds-divider orientation="vertical" variant="discrete"></tds-divider>
+      <span>soft</span>
+      <tds-divider orientation="vertical" variant="soft"></tds-divider>
+      <span>defined</span>
+      <tds-divider orientation="vertical" variant="defined"></tds-divider>
+      <span>dark-blue</span>
+      <tds-divider orientation="vertical" variant="dark-blue"></tds-divider>
     </div>
   </div>
 
+  <!-- Divider in context -->
   <div class="tds-u-pt2">
     <p class="tds-detail-02 tds-u-pb1">Divider separating content blocks</p>
     <p>First block of content above the divider.</p>

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -1,5 +1,294 @@
 <h3>About this page</h3>
 <p>
-  This page is a testing ground and demo for using &#64;scania/tegel-angular in
-  an Angular application.
+  This page is a testing ground for the variable migration in
+  <b>&#64;scania/tegel-angular-17&#64;1.51.0-var-work-beta.2</b>. It showcases the
+  affected components (Link, Breadcrumbs, Divider, Footer) in multiple states
+  so every edge case is testable. Use the Brand toggle in the top-right corner
+  to switch between the Scania and Traton brands.
 </p>
+
+<!-- LINKS -->
+<section class="tds-u-pt3">
+  <h4 class="tds-headline-03">Link</h4>
+
+  <div class="tds-u-pt1">
+    <p class="tds-detail-02 tds-u-pb1">Default link</p>
+    <tds-link>
+      <a href="https://tegel.scania.com/home" target="_blank">Default link</a>
+    </tds-link>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Link inside a paragraph</p>
+    <p>
+      Visit the
+      <tds-link>
+        <a href="https://tegel.scania.com/home" target="_blank">Tegel documentation</a>
+      </tds-link>
+      for more information about the design system.
+    </p>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Disabled link</p>
+    <tds-link disabled>
+      <a href="https://tegel.scania.com/home" target="_blank">Disabled link</a>
+    </tds-link>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Link without underline</p>
+    <tds-link no-underline>
+      <a href="https://tegel.scania.com/home" target="_blank">No underline link</a>
+    </tds-link>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Long link that may wrap</p>
+    <tds-link>
+      <a href="https://tegel.scania.com/home" target="_blank">
+        This is a very long link that should wrap to a new line to verify
+        underline and hover states behave correctly when the text breaks.
+      </a>
+    </tds-link>
+  </div>
+</section>
+
+<!-- BREADCRUMBS -->
+<section class="tds-u-pt3">
+  <h4 class="tds-headline-03">Breadcrumbs</h4>
+
+  <div class="tds-u-pt1">
+    <p class="tds-detail-02 tds-u-pb1">Single breadcrumb (current)</p>
+    <tds-breadcrumbs>
+      <tds-breadcrumb [current]="true">
+        <a href="#">Current page</a>
+      </tds-breadcrumb>
+    </tds-breadcrumbs>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Two-level breadcrumbs</p>
+    <tds-breadcrumbs>
+      <tds-breadcrumb>
+        <a href="#">Home</a>
+      </tds-breadcrumb>
+      <tds-breadcrumb [current]="true">
+        <a href="#">About</a>
+      </tds-breadcrumb>
+    </tds-breadcrumbs>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Multi-level breadcrumbs (standard)</p>
+    <tds-breadcrumbs>
+      <tds-breadcrumb>
+        <a href="#">Home</a>
+      </tds-breadcrumb>
+      <tds-breadcrumb>
+        <a href="#">Components</a>
+      </tds-breadcrumb>
+      <tds-breadcrumb>
+        <a href="#">Navigation</a>
+      </tds-breadcrumb>
+      <tds-breadcrumb [current]="true">
+        <a href="#">Breadcrumbs</a>
+      </tds-breadcrumb>
+    </tds-breadcrumbs>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Long breadcrumbs (tests divider and truncation)</p>
+    <tds-breadcrumbs>
+      <tds-breadcrumb>
+        <a href="#">A very long root page title</a>
+      </tds-breadcrumb>
+      <tds-breadcrumb>
+        <a href="#">Another long section name</a>
+      </tds-breadcrumb>
+      <tds-breadcrumb>
+        <a href="#">Sub-category with many words</a>
+      </tds-breadcrumb>
+      <tds-breadcrumb>
+        <a href="#">Deep nested item</a>
+      </tds-breadcrumb>
+      <tds-breadcrumb [current]="true">
+        <a href="#">Current deeply nested page</a>
+      </tds-breadcrumb>
+    </tds-breadcrumbs>
+  </div>
+</section>
+
+<!-- DIVIDER -->
+<section class="tds-u-pt3">
+  <h4 class="tds-headline-03">Divider</h4>
+
+  <div class="tds-u-pt1">
+    <p class="tds-detail-02 tds-u-pb1">Default horizontal divider</p>
+    <tds-divider></tds-divider>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Light horizontal divider</p>
+    <tds-divider type="light"></tds-divider>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Strong horizontal divider</p>
+    <tds-divider type="strong"></tds-divider>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Vertical divider (default / light / strong)</p>
+    <div class="tds-u-flex tds-u-gap2" style="height: 48px; align-items: center;">
+      <span>Left</span>
+      <tds-divider orientation="vertical"></tds-divider>
+      <span>Middle</span>
+      <tds-divider orientation="vertical" type="light"></tds-divider>
+      <span>After light</span>
+      <tds-divider orientation="vertical" type="strong"></tds-divider>
+      <span>Right</span>
+    </div>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Divider separating content blocks</p>
+    <p>First block of content above the divider.</p>
+    <tds-divider></tds-divider>
+    <p class="tds-u-pt1">Second block of content below the divider.</p>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<section class="tds-u-pt3">
+  <h4 class="tds-headline-03">Footer</h4>
+
+  <div class="tds-u-pt1">
+    <p class="tds-detail-02 tds-u-pb1">Full footer (top + start + end)</p>
+    <tds-footer>
+      <div slot="top">
+        <tds-footer-group title-text="Pages">
+          <tds-footer-item>
+            <a href="#">Home</a>
+          </tds-footer-item>
+          <tds-footer-item>
+            <a href="#">Form</a>
+          </tds-footer-item>
+        </tds-footer-group>
+        <tds-footer-group title-text="Legals">
+          <tds-footer-item>
+            <a href="#">Terms &amp; Conditions</a>
+          </tds-footer-item>
+          <tds-footer-item>
+            <a href="#">Privacy policy</a>
+          </tds-footer-item>
+        </tds-footer-group>
+        <tds-footer-group title-text="Design">
+          <tds-footer-item>
+            <a href="#">Grid system</a>
+          </tds-footer-item>
+          <tds-footer-item>
+            <a href="#">Icons</a>
+          </tds-footer-item>
+        </tds-footer-group>
+        <tds-footer-group title-text="Support">
+          <tds-footer-item>
+            <a href="#">Contact</a>
+          </tds-footer-item>
+          <tds-footer-item>
+            <a href="#">FAQ</a>
+          </tds-footer-item>
+        </tds-footer-group>
+      </div>
+      <div slot="start">
+        <tds-footer-group>
+          <tds-footer-item>
+            <a href="#">Link text</a>
+          </tds-footer-item>
+          <tds-footer-item>
+            <a href="#">Link text</a>
+          </tds-footer-item>
+          <tds-footer-item>
+            <a href="#">Link text</a>
+          </tds-footer-item>
+        </tds-footer-group>
+      </div>
+      <div slot="end">
+        <tds-footer-group>
+          <tds-footer-item>
+            <a href="#">
+              <tds-icon name="truck"></tds-icon>
+            </a>
+          </tds-footer-item>
+          <tds-footer-item>
+            <a href="#">
+              <tds-icon name="truck"></tds-icon>
+            </a>
+          </tds-footer-item>
+          <tds-footer-item>
+            <a href="#">
+              <tds-icon name="truck"></tds-icon>
+            </a>
+          </tds-footer-item>
+        </tds-footer-group>
+      </div>
+    </tds-footer>
+  </div>
+
+  <div class="tds-u-pt3">
+    <p class="tds-detail-02 tds-u-pb1">Minimal footer (start only — copyright)</p>
+    <tds-footer>
+      <div slot="start">
+        <tds-footer-group>
+          <tds-footer-item>
+            <a href="#">&copy; Scania</a>
+          </tds-footer-item>
+        </tds-footer-group>
+      </div>
+    </tds-footer>
+  </div>
+
+  <div class="tds-u-pt3">
+    <p class="tds-detail-02 tds-u-pb1">Footer with only top section</p>
+    <tds-footer>
+      <div slot="top">
+        <tds-footer-group title-text="Resources">
+          <tds-footer-item>
+            <a href="#">Docs</a>
+          </tds-footer-item>
+          <tds-footer-item>
+            <a href="#">GitHub</a>
+          </tds-footer-item>
+        </tds-footer-group>
+        <tds-footer-group title-text="Community">
+          <tds-footer-item>
+            <a href="#">Slack</a>
+          </tds-footer-item>
+          <tds-footer-item>
+            <a href="#">Forum</a>
+          </tds-footer-item>
+        </tds-footer-group>
+      </div>
+    </tds-footer>
+  </div>
+
+  <div class="tds-u-pt3">
+    <p class="tds-detail-02 tds-u-pb1">Footer with end slot only (social icons)</p>
+    <tds-footer>
+      <div slot="end">
+        <tds-footer-group>
+          <tds-footer-item>
+            <a href="#">
+              <tds-icon name="truck"></tds-icon>
+            </a>
+          </tds-footer-item>
+          <tds-footer-item>
+            <a href="#">
+              <tds-icon name="truck"></tds-icon>
+            </a>
+          </tds-footer-item>
+        </tds-footer-group>
+      </div>
+    </tds-footer>
+  </div>
+</section>


### PR DESCRIPTION
## Summary

- Installs `@scania/tegel-angular-17@1.51.0-var-work-beta.2` to test the CSS variable migration scoped to **Link**, **Breadcrumbs**, **Divider** and **Footer**.
- Extends the About page into a dedicated test ground for those four components, covering multiple states (default, long text, disabled, light/strong/vertical divider variants, single/two-level/multi-level/long breadcrumbs, full/minimal/top-only/end-only footer).
- Adds a Brand switcher next to the Mode / Mode variant toggles that adds/removes `.scania` / `.traton` on the `<body>` tag so both brands can be visually verified in one session.

## Test plan

- [ ] `npm install && npm start`
- [ ] Navigate to `/about`
- [ ] Toggle Light/Dark mode and Primary/Secondary variant — verify Link, Breadcrumbs, Divider and Footer tokens render correctly in all four combinations.
- [ ] Toggle the Brand switch — verify the body class flips between `.scania` and `.traton` and the components pick up the brand-specific variables.
- [ ] Hover/focus each Link variant (default, disabled, no-underline, long wrapping) and confirm the underline and color tokens.
- [ ] Inspect each Breadcrumbs block — confirm the divider between items, the current-page styling, and wrapping of the long variant.
- [ ] Inspect each Divider variant (default / light / strong, horizontal and vertical) and confirm the token-driven color.
- [ ] Inspect each Footer block (full, minimal, top-only, end-only) and confirm typography, link, divider and icon tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)