### PR TITLE
test: 1.51.0-var-work-beta.3 — button/tooltip/tag migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-angular-17": "1.51.0",
+        "@scania/tegel-angular-17": "1.51.0-var-work-beta.3",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/angular-table": "^8.19.2",
         "ag-grid-angular": "^31.3.2",
@@ -4137,9 +4137,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4153,9 +4150,6 @@
       "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4185,9 +4179,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4201,9 +4192,6 @@
       "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4232,9 +4220,6 @@
       "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4370,9 +4355,9 @@
       ]
     },
     "node_modules/@scania/tegel": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0.tgz",
-      "integrity": "sha512-wChnv7mnY0aLWxMcCKPmcp2x81z6zzv0wchQTXHjf2YBu9AQRmZD2va+ldD+etO/wXc5jrGtHkpudcn/T9YKxg==",
+      "version": "1.51.0-var-work-beta.3",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.3.tgz",
+      "integrity": "sha512-t+I5oRfSaDFV9Dm/Mv6RzBmu+IcB61v0bNdnmbQdXxNQRCP/y/LMflPP2X0RkK0aE8PpORnYYsKZE3bsrG4z8g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4386,16 +4371,16 @@
       }
     },
     "node_modules/@scania/tegel-angular-17": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0.tgz",
-      "integrity": "sha512-bBiwghjHA7aCZDSN0Zj9rAdKs3HpqhQcSJef+9/aUbxnYtqLsS3SEorshT88E9OWB7Pbfn2hGbEQ1f/re8YJjw==",
+      "version": "1.51.0-var-work-beta.3",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.51.0-var-work-beta.3.tgz",
+      "integrity": "sha512-Ksz3bc8PD8x4EUv2cC2bTXGmZKgkVe57UnVSc61a8zzxlwiO1FfphsDzG/LBYW8utAau5yJejQeF/iTijM/GbA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">=17.0.0",
         "@angular/core": ">=17.0.0",
-        "@scania/tegel": "^1.51.0"
+        "@scania/tegel": "1.51.0-var-work-beta.3"
       }
     },
     "node_modules/@scania/tegel-styles": {
@@ -4879,9 +4864,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4895,9 +4877,6 @@
       "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4913,9 +4892,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4929,9 +4905,6 @@
       "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4947,9 +4920,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4963,9 +4933,6 @@
       "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4981,9 +4948,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4997,9 +4961,6 @@
       "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5437,9 +5398,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5453,9 +5411,6 @@
       "integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5471,9 +5426,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5487,9 +5439,6 @@
       "integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7919,6 +7868,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8799,7 +8749,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/handle-thing": {
@@ -9163,6 +9113,7 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
       "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -10163,6 +10114,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10177,6 +10129,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -10190,6 +10143,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -10200,6 +10154,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
@@ -11111,6 +11066,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
       "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11128,6 +11084,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12003,6 +11960,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -12267,6 +12225,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -12822,7 +12781,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -12888,6 +12847,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-angular-17": "1.51.0",
+    "@scania/tegel-angular-17": "1.51.0-var-work-beta.3",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/angular-table": "^8.19.2",
     "ag-grid-angular": "^31.3.2",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -211,6 +211,7 @@
             <app-mode-variant-switcher
               (modeVariantToggle)="handleModeVariantToggle()"
             ></app-mode-variant-switcher>
+            <app-brand-switcher></app-brand-switcher>
           </div>
           <div class="tds-u-h-100 tds-u-flex tds-u-flex-dir-col">
             <nav-breadcrumbs *ngIf="!is404page"></nav-breadcrumbs>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,6 +9,7 @@ import {
 } from "@angular/router";
 import { ModeSwitcherComponent } from "./mode-switcher/mode-switcher.component";
 import { ModeVariantSwitcherComponent } from "./mode-variant-switcher/mode-variant-switcher.component";
+import { BrandSwitcherComponent } from "./brand-switcher/brand-switcher.component";
 import BreadcrumbsComponent from "./navigation/breadcrumbs/breadcrumbs.component";
 import { BannerComponent } from "@components/banner/banner.component";
 import { UserStoreService } from "./services/user-store.service";
@@ -30,6 +31,7 @@ import { TegelModule } from "@scania/tegel-angular-17";
     BreadcrumbsComponent,
     ModeSwitcherComponent,
     ModeVariantSwitcherComponent,
+    BrandSwitcherComponent,
     CommonModule,
     TegelModule,
   ],

--- a/src/app/brand-switcher/brand-switcher.component.html
+++ b/src/app/brand-switcher/brand-switcher.component.html
@@ -1,0 +1,7 @@
+<tds-toggle
+  (tdsToggle)="toggleBrand()"
+  headline="Brand"
+  size="sm"
+>
+  <div slot="label">{{ labelText }}</div>
+</tds-toggle>

--- a/src/app/brand-switcher/brand-switcher.component.ts
+++ b/src/app/brand-switcher/brand-switcher.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit } from "@angular/core";
+import { TegelModule } from "@scania/tegel-angular-17";
+
+@Component({
+  selector: "app-brand-switcher",
+  templateUrl: "./brand-switcher.component.html",
+  standalone: true,
+  imports: [TegelModule],
+})
+export class BrandSwitcherComponent implements OnInit {
+  brand: "scania" | "traton" = "scania";
+  labelText: "Scania" | "Traton" = "Scania";
+
+  ngOnInit(): void {
+    this.applyBrand();
+  }
+
+  toggleBrand() {
+    this.brand = this.brand === "scania" ? "traton" : "scania";
+    this.labelText = this.brand === "scania" ? "Scania" : "Traton";
+    this.applyBrand();
+  }
+
+  private applyBrand() {
+    const body = document.body;
+    body.classList.remove("scania", "traton");
+    body.classList.add(this.brand);
+  }
+}

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -1,5 +1,255 @@
 <h3>About this page</h3>
 <p>
-  This page is a testing ground and demo for using &#64;scania/tegel-angular in
-  an Angular application.
+  This page is a testing ground for the variable migration in
+  <b>&#64;scania/tegel-angular-17&#64;1.51.0-var-work-beta.3</b>. It showcases
+  the affected components (Button, Tooltip, Tag) in multiple states so every
+  edge case is testable. Use the Brand toggle in the top-right corner to
+  switch between the Scania and Traton brands.
 </p>
+
+<!-- BUTTONS -->
+<section class="tds-u-pt3">
+  <h4 class="tds-headline-03">Button</h4>
+
+  <!-- Variant x size matrix (enabled) -->
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">All variants — size lg</p>
+    <div class="tds-u-flex tds-u-gap1 tds-u-flex-wrap">
+      <tds-button variant="primary" size="lg" text="Primary"></tds-button>
+      <tds-button variant="secondary" size="lg" text="Secondary"></tds-button>
+      <tds-button variant="ghost" size="lg" text="Ghost"></tds-button>
+      <tds-button variant="danger" size="lg" text="Danger"></tds-button>
+    </div>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">All variants — size md</p>
+    <div class="tds-u-flex tds-u-gap1 tds-u-flex-wrap">
+      <tds-button variant="primary" size="md" text="Primary"></tds-button>
+      <tds-button variant="secondary" size="md" text="Secondary"></tds-button>
+      <tds-button variant="ghost" size="md" text="Ghost"></tds-button>
+      <tds-button variant="danger" size="md" text="Danger"></tds-button>
+    </div>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">All variants — size sm</p>
+    <div class="tds-u-flex tds-u-gap1 tds-u-flex-wrap">
+      <tds-button variant="primary" size="sm" text="Primary"></tds-button>
+      <tds-button variant="secondary" size="sm" text="Secondary"></tds-button>
+      <tds-button variant="ghost" size="sm" text="Ghost"></tds-button>
+      <tds-button variant="danger" size="sm" text="Danger"></tds-button>
+    </div>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">All variants — size xs</p>
+    <div class="tds-u-flex tds-u-gap1 tds-u-flex-wrap">
+      <tds-button variant="primary" size="xs" text="Primary"></tds-button>
+      <tds-button variant="secondary" size="xs" text="Secondary"></tds-button>
+      <tds-button variant="ghost" size="xs" text="Ghost"></tds-button>
+      <tds-button variant="danger" size="xs" text="Danger"></tds-button>
+    </div>
+  </div>
+
+  <!-- Disabled -->
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Disabled — all variants, size md</p>
+    <div class="tds-u-flex tds-u-gap1 tds-u-flex-wrap">
+      <tds-button variant="primary" size="md" text="Primary" disabled></tds-button>
+      <tds-button variant="secondary" size="md" text="Secondary" disabled></tds-button>
+      <tds-button variant="ghost" size="md" text="Ghost" disabled></tds-button>
+      <tds-button variant="danger" size="md" text="Danger" disabled></tds-button>
+    </div>
+  </div>
+
+  <!-- With icons -->
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">With leading icon</p>
+    <div class="tds-u-flex tds-u-gap1 tds-u-flex-wrap">
+      <tds-button variant="primary" size="md" text="Download">
+        <tds-icon slot="icon" size="16px" name="download"></tds-icon>
+      </tds-button>
+      <tds-button variant="secondary" size="md" text="Upload">
+        <tds-icon slot="icon" size="16px" name="upload"></tds-icon>
+      </tds-button>
+      <tds-button variant="ghost" size="md" text="Edit">
+        <tds-icon slot="icon" size="16px" name="edit"></tds-icon>
+      </tds-button>
+      <tds-button variant="danger" size="md" text="Delete">
+        <tds-icon slot="icon" size="16px" name="error"></tds-icon>
+      </tds-button>
+    </div>
+  </div>
+
+  <!-- Icon only -->
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Icon only</p>
+    <div class="tds-u-flex tds-u-gap1 tds-u-flex-wrap">
+      <tds-button variant="primary" size="md">
+        <tds-icon slot="icon" size="16px" name="truck"></tds-icon>
+      </tds-button>
+      <tds-button variant="secondary" size="md">
+        <tds-icon slot="icon" size="16px" name="settings"></tds-icon>
+      </tds-button>
+      <tds-button variant="ghost" size="md">
+        <tds-icon slot="icon" size="16px" name="info"></tds-icon>
+      </tds-button>
+      <tds-button variant="danger" size="md">
+        <tds-icon slot="icon" size="16px" name="error"></tds-icon>
+      </tds-button>
+    </div>
+  </div>
+
+  <!-- Fullbleed -->
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Fullbleed — all variants</p>
+    <div class="tds-u-flex tds-u-flex-dir-col tds-u-gap1">
+      <tds-button variant="primary" size="lg" fullbleed text="Primary fullbleed"></tds-button>
+      <tds-button variant="secondary" size="lg" fullbleed text="Secondary fullbleed"></tds-button>
+      <tds-button variant="ghost" size="lg" fullbleed text="Ghost fullbleed"></tds-button>
+      <tds-button variant="danger" size="lg" fullbleed text="Danger fullbleed"></tds-button>
+      <tds-button variant="primary" size="lg" fullbleed text="Primary fullbleed (disabled)" disabled></tds-button>
+    </div>
+  </div>
+</section>
+
+<!-- TOOLTIP -->
+<section class="tds-u-pt3">
+  <h4 class="tds-headline-03">Tooltip</h4>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Placements</p>
+    <div class="tds-u-flex tds-u-gap3 tds-u-flex-wrap" style="padding: 48px 0;">
+      <tds-button size="sm" id="tooltip-top" text="Top"></tds-button>
+      <tds-tooltip
+        placement="top"
+        selector="#tooltip-top"
+        text="Top tooltip"
+        mouse-over-tooltip="true"
+      ></tds-tooltip>
+
+      <tds-button size="sm" id="tooltip-right" text="Right"></tds-button>
+      <tds-tooltip
+        placement="right"
+        selector="#tooltip-right"
+        text="Right tooltip"
+        mouse-over-tooltip="true"
+      ></tds-tooltip>
+
+      <tds-button size="sm" id="tooltip-bottom" text="Bottom"></tds-button>
+      <tds-tooltip
+        placement="bottom"
+        selector="#tooltip-bottom"
+        text="Bottom tooltip"
+        mouse-over-tooltip="true"
+      ></tds-tooltip>
+
+      <tds-button size="sm" id="tooltip-left" text="Left"></tds-button>
+      <tds-tooltip
+        placement="left"
+        selector="#tooltip-left"
+        text="Left tooltip"
+        mouse-over-tooltip="true"
+      ></tds-tooltip>
+    </div>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Tooltip with rich content (paragraph, bold, italic)</p>
+    <div class="tds-u-flex tds-u-align-center tds-u-justify-center" style="padding: 32px 0;">
+      <tds-button size="sm" id="tooltip-rich" text="Hover me"></tds-button>
+      <tds-tooltip
+        placement="bottom"
+        selector="#tooltip-rich"
+        mouse-over-tooltip="true"
+      >
+        <p class="tds-detail-05 tds-u-m0">
+          Rich content with <b>bold</b> and <i>italic</i> tags inside.
+        </p>
+      </tds-tooltip>
+    </div>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Tooltip with long text (tests wrapping)</p>
+    <div class="tds-u-flex tds-u-align-center tds-u-justify-center" style="padding: 32px 0;">
+      <tds-button size="sm" id="tooltip-long" text="Long tooltip"></tds-button>
+      <tds-tooltip
+        placement="bottom"
+        selector="#tooltip-long"
+        text="This is a tooltip with a long description that should wrap across multiple lines so the background, padding and text variables can be verified."
+        mouse-over-tooltip="true"
+      ></tds-tooltip>
+    </div>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Tooltip on a tag</p>
+    <div class="tds-u-flex tds-u-align-center tds-u-justify-center" style="padding: 32px 0;">
+      <tds-tag id="tooltip-tag" text="Hover tag" variant="Information" size="lg"></tds-tag>
+      <tds-tooltip
+        placement="top"
+        selector="#tooltip-tag"
+        text="Tooltip anchored on a tag"
+        mouse-over-tooltip="true"
+      ></tds-tooltip>
+    </div>
+  </div>
+</section>
+
+<!-- TAG -->
+<section class="tds-u-pt3">
+  <h4 class="tds-headline-03">Tag</h4>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">All variants — size lg</p>
+    <div class="tds-u-flex tds-u-gap2 tds-u-flex-wrap">
+      <tds-tag text="Neutral" variant="Neutral" size="lg"></tds-tag>
+      <tds-tag text="Success" variant="Success" size="lg"></tds-tag>
+      <tds-tag text="Warning" variant="Warning" size="lg"></tds-tag>
+      <tds-tag text="Error" variant="Error" size="lg"></tds-tag>
+      <tds-tag text="Information" variant="Information" size="lg"></tds-tag>
+      <tds-tag text="New" variant="New" size="lg"></tds-tag>
+    </div>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">All variants — size sm</p>
+    <div class="tds-u-flex tds-u-gap2 tds-u-flex-wrap">
+      <tds-tag text="Neutral" variant="Neutral" size="sm"></tds-tag>
+      <tds-tag text="Success" variant="Success" size="sm"></tds-tag>
+      <tds-tag text="Warning" variant="Warning" size="sm"></tds-tag>
+      <tds-tag text="Error" variant="Error" size="sm"></tds-tag>
+      <tds-tag text="Information" variant="Information" size="sm"></tds-tag>
+      <tds-tag text="New" variant="New" size="sm"></tds-tag>
+    </div>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Tags with prefix icons</p>
+    <div class="tds-u-flex tds-u-gap2 tds-u-flex-wrap">
+      <tds-tag text="With Icon" variant="Success" size="lg">
+        <tds-icon name="check" size="16px" slot="prefix"></tds-icon>
+      </tds-tag>
+      <tds-tag text="Warning" variant="Warning" size="lg">
+        <tds-icon name="warning" size="16px" slot="prefix"></tds-icon>
+      </tds-tag>
+      <tds-tag text="Error" variant="Error" size="lg">
+        <tds-icon name="error" size="16px" slot="prefix"></tds-icon>
+      </tds-tag>
+      <tds-tag text="Info" variant="Information" size="lg">
+        <tds-icon name="info" size="16px" slot="prefix"></tds-icon>
+      </tds-tag>
+    </div>
+  </div>
+
+  <div class="tds-u-pt2">
+    <p class="tds-detail-02 tds-u-pb1">Tags with long text (tests wrapping / truncation)</p>
+    <div class="tds-u-flex tds-u-gap2 tds-u-flex-wrap">
+      <tds-tag text="A very long neutral tag label" variant="Neutral" size="lg"></tds-tag>
+      <tds-tag text="Another long informational label" variant="Information" size="lg"></tds-tag>
+      <tds-tag text="Small but still long label" variant="Success" size="sm"></tds-tag>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary

- Installs `@scania/tegel-angular-17@1.51.0-var-work-beta.3` to test the CSS variable migration scoped to **Button**, **Tooltip** and **Tag**.
- Extends the About page into a dedicated test ground for those three components, covering multiple states (every variant x every size, disabled, with leading icon, icon-only, fullbleed, all tooltip placements, rich/long/anchored-on-tag tooltip content, every tag variant in lg/sm plus prefix-icon and long-label edge cases).
- Adds a Brand switcher next to the Mode / Mode variant toggles that adds/removes `.scania` / `.traton` on the `<body>` tag so both brands can be visually verified in one session.

## Test plan

- [ ] `npm install && npm start`
- [ ] Navigate to `/about`
- [ ] Toggle Light/Dark mode and Primary/Secondary variant — verify Button, Tooltip and Tag tokens render correctly in all four combinations.
- [ ] Toggle the Brand switch — verify the body class flips between `.scania` and `.traton` and the components pick up the brand-specific variables.
- [ ] Hover/focus each Button variant and size (lg/md/sm/xs, primary/secondary/ghost/danger, disabled, with icon, icon-only, fullbleed).
- [ ] Hover each Tooltip example — confirm placement (top/right/bottom/left), background, text and border tokens; verify long and rich-content tooltips.
- [ ] Inspect each Tag (all variants in lg and sm, with prefix icon, long labels) and confirm color, border and typography tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)