### PR TITLE
feat: beta test page for variable-migration (Link, Breadcrumbs, Divider, Footer)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-angular-17": "1.52.0",
+        "@scania/tegel-angular-17": "1.52.0-var-work-beta.0",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/angular-table": "^8.19.2",
         "ag-grid-angular": "^31.3.2",
@@ -4047,9 +4047,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
       "cpu": [
         "arm64"
       ],
@@ -4061,9 +4061,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
       "cpu": [
         "x64"
       ],
@@ -4131,9 +4131,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
       "cpu": [
         "loong64"
       ],
@@ -4145,9 +4145,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
       ],
@@ -4173,9 +4173,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
       "cpu": [
         "ppc64"
       ],
@@ -4187,9 +4187,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
       ],
@@ -4215,9 +4215,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
       ],
@@ -4271,9 +4271,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
       "cpu": [
         "x64"
       ],
@@ -4285,9 +4285,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
       "cpu": [
         "arm64"
       ],
@@ -4327,9 +4327,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
       "cpu": [
         "x64"
       ],
@@ -4355,9 +4355,9 @@
       ]
     },
     "node_modules/@scania/tegel": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.52.0.tgz",
-      "integrity": "sha512-QCe8Kma07URhEyx3BkhBeBSduZFZgx/Hw4RBxiZuyB9Oju14eacQNYIdTHrB2v5psgZdEIqhZWBDWe9bZImorw==",
+      "version": "1.52.0-var-work-beta.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.52.0-var-work-beta.0.tgz",
+      "integrity": "sha512-rbMvQ51fB4uoy+2MZbFDL5lCilpAn3xZpUHZg1sAg+pGzOHylEkGMXjZUaBU+Blpv0RPMdVIgfXm2a1Mi5Sh6Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4371,16 +4371,16 @@
       }
     },
     "node_modules/@scania/tegel-angular-17": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.52.0.tgz",
-      "integrity": "sha512-ZoRzvbubaxAbh+h/y6B8OSkuL9eEhYZ5If/tvnmDQfAF1naxh2ROl8drUxBe6msbVUvtFHGobL41FaahLglGGg==",
+      "version": "1.52.0-var-work-beta.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.52.0-var-work-beta.0.tgz",
+      "integrity": "sha512-/12tNQLakdwKkbt2kuanWLACfxr+Atp8U8GLUdgTAtRCLHTbc4l88ddNvA4drbLPHF6UPFCOH9nPhvLwioqW9g==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">=17.0.0",
         "@angular/core": ">=17.0.0",
-        "@scania/tegel": "^1.52.0"
+        "@scania/tegel": "1.52.0-var-work-beta.0"
       }
     },
     "node_modules/@scania/tegel-styles": {
@@ -4802,9 +4802,9 @@
       }
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
       "cpu": [
         "arm"
       ],
@@ -4816,9 +4816,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
       "cpu": [
         "arm64"
       ],
@@ -4830,9 +4830,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
       "cpu": [
         "arm64"
       ],
@@ -4844,9 +4844,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
       "cpu": [
         "x64"
       ],
@@ -4858,9 +4858,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
       "cpu": [
         "arm"
       ],
@@ -4872,9 +4872,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
       ],
@@ -4886,9 +4886,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
       "cpu": [
         "arm64"
       ],
@@ -4900,9 +4900,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
       ],
@@ -4914,9 +4914,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
       "cpu": [
         "riscv64"
       ],
@@ -4928,9 +4928,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
       "cpu": [
         "s390x"
       ],
@@ -4942,9 +4942,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
       ],
@@ -4956,9 +4956,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
       ],
@@ -4970,9 +4970,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
       "cpu": [
         "arm64"
       ],
@@ -4984,9 +4984,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
       "cpu": [
         "ia32"
       ],
@@ -4998,9 +4998,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel/node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
       "cpu": [
         "x64"
       ],
@@ -5103,9 +5103,9 @@
       }
     },
     "node_modules/@scania/tegel/node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5119,31 +5119,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-angular-17": "1.52.0",
+    "@scania/tegel-angular-17": "1.52.0-var-work-beta.0",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/angular-table": "^8.19.2",
     "ag-grid-angular": "^31.3.2",

--- a/src/app/pages/about-page/about-page.component.css
+++ b/src/app/pages/about-page/about-page.component.css
@@ -1,0 +1,62 @@
+.beta-page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.brand-toggle {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--tds-grey-50, #f9fafb);
+  border: 1px solid var(--tds-grey-200, #e4e7eb);
+  border-radius: 4px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--tds-grey-200, #e4e7eb);
+  border-radius: 4px;
+}
+
+.state-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 0;
+}
+
+.state-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.7;
+}
+
+.divider-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.divider-vertical-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  height: 80px;
+}
+
+.divider-vertical-row > span {
+  white-space: nowrap;
+}
+
+.inline-links {
+  line-height: 1.8;
+}

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -1,5 +1,349 @@
-<h3>About this page</h3>
-<p>
-  This page is a testing ground and demo for using &#64;scania/tegel-angular in
-  an Angular application.
-</p>
+<div class="beta-page">
+  <header>
+    <h3>About this page</h3>
+    <p>
+      Testing ground for the
+      <strong>1.52.0-var-work-beta.0</strong> beta of
+      &#64;scania/tegel-angular-17. The sections below cover the components
+      affected by the variable-migration work: Link, Breadcrumbs, Divider and
+      Footer, across multiple states and both brands.
+    </p>
+  </header>
+
+  <section class="brand-toggle" aria-label="Brand toggle">
+    <strong>Brand:</strong>
+    <tds-radio-button
+      name="brand"
+      value="scania"
+      radio-id="brand-scania"
+      [checked]="brand === 'scania'"
+      (tdsChange)="setBrand('scania')"
+    >
+      <div slot="label">Scania (.scania)</div>
+    </tds-radio-button>
+    <tds-radio-button
+      name="brand"
+      value="traton"
+      radio-id="brand-traton"
+      [checked]="brand === 'traton'"
+      (tdsChange)="setBrand('traton')"
+    >
+      <div slot="label">Traton (.traton)</div>
+    </tds-radio-button>
+    <span class="state-label">
+      Active body class: <code>.{{ brand }}</code>
+    </span>
+  </section>
+
+  <!-- LINK -->
+  <section class="section" aria-labelledby="section-link">
+    <h4 id="section-link" class="tds-headline-03">Link</h4>
+
+    <div class="state-row">
+      <span class="state-label">Default (inline)</span>
+      <p class="inline-links">
+        Lorem ipsum dolor sit amet, consectetur
+        <tds-link>
+          <a href="https://tegel.scania.com" target="_blank">default link</a>
+        </tds-link>
+        adipiscing elit.
+      </p>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Underline</span>
+      <p class="inline-links">
+        Lorem ipsum
+        <tds-link underline="true">
+          <a href="https://tegel.scania.com" target="_blank">underlined link</a>
+        </tds-link>
+        dolor sit amet.
+      </p>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Standalone</span>
+      <tds-link standalone="true">
+        <a href="https://tegel.scania.com" target="_blank">Standalone link</a>
+      </tds-link>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Standalone + underline</span>
+      <tds-link standalone="true" underline="true">
+        <a href="https://tegel.scania.com" target="_blank">
+          Standalone underlined link
+        </a>
+      </tds-link>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Disabled</span>
+      <tds-link disabled="true">
+        <a href="https://tegel.scania.com" target="_blank">Disabled link</a>
+      </tds-link>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Disabled + standalone</span>
+      <tds-link disabled="true" standalone="true">
+        <a href="https://tegel.scania.com" target="_blank">
+          Disabled standalone link
+        </a>
+      </tds-link>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Long text (wrapping)</span>
+      <p class="inline-links">
+        <tds-link>
+          <a href="https://tegel.scania.com" target="_blank">
+            This is a very long link label that should gracefully wrap across
+            multiple lines so that wrap behavior can be visually inspected
+          </a>
+        </tds-link>
+      </p>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">With icon</span>
+      <tds-link standalone="true">
+        <a href="https://tegel.scania.com" target="_blank">
+          Link with trailing icon
+          <tds-icon name="arrow_right" size="16"></tds-icon>
+        </a>
+      </tds-link>
+    </div>
+  </section>
+
+  <!-- BREADCRUMBS -->
+  <section class="section" aria-labelledby="section-breadcrumbs">
+    <h4 id="section-breadcrumbs" class="tds-headline-03">Breadcrumbs</h4>
+
+    <div class="state-row">
+      <span class="state-label">Single item (current only)</span>
+      <tds-breadcrumbs tdsAriaLabel="Single breadcrumb">
+        <tds-breadcrumb [current]="true">
+          <a href="#">Only page</a>
+        </tds-breadcrumb>
+      </tds-breadcrumbs>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Two levels</span>
+      <tds-breadcrumbs tdsAriaLabel="Two level breadcrumb">
+        <tds-breadcrumb>
+          <a href="#">Home</a>
+        </tds-breadcrumb>
+        <tds-breadcrumb [current]="true">
+          <a href="#">Current</a>
+        </tds-breadcrumb>
+      </tds-breadcrumbs>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Default (three levels)</span>
+      <tds-breadcrumbs tdsAriaLabel="Three level breadcrumb">
+        <tds-breadcrumb>
+          <a href="#">Home</a>
+        </tds-breadcrumb>
+        <tds-breadcrumb>
+          <a href="#">Section</a>
+        </tds-breadcrumb>
+        <tds-breadcrumb [current]="true">
+          <a href="#">Current page</a>
+        </tds-breadcrumb>
+      </tds-breadcrumbs>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Many levels (overflow / wrapping)</span>
+      <tds-breadcrumbs tdsAriaLabel="Deep breadcrumb">
+        <tds-breadcrumb>
+          <a href="#">Home</a>
+        </tds-breadcrumb>
+        <tds-breadcrumb>
+          <a href="#">Vehicles</a>
+        </tds-breadcrumb>
+        <tds-breadcrumb>
+          <a href="#">Heavy trucks</a>
+        </tds-breadcrumb>
+        <tds-breadcrumb>
+          <a href="#">Long haul</a>
+        </tds-breadcrumb>
+        <tds-breadcrumb>
+          <a href="#">Configuration</a>
+        </tds-breadcrumb>
+        <tds-breadcrumb [current]="true">
+          <a href="#">Summary with a very long label for wrap testing</a>
+        </tds-breadcrumb>
+      </tds-breadcrumbs>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Without current flag</span>
+      <tds-breadcrumbs tdsAriaLabel="No current breadcrumb">
+        <tds-breadcrumb>
+          <a href="#">Home</a>
+        </tds-breadcrumb>
+        <tds-breadcrumb>
+          <a href="#">Section</a>
+        </tds-breadcrumb>
+        <tds-breadcrumb>
+          <a href="#">Last (no current)</a>
+        </tds-breadcrumb>
+      </tds-breadcrumbs>
+    </div>
+  </section>
+
+  <!-- DIVIDER -->
+  <section class="section" aria-labelledby="section-divider">
+    <h4 id="section-divider" class="tds-headline-03">Divider</h4>
+
+    <div class="divider-grid">
+      <div class="state-row" *ngFor="let variant of dividerVariants">
+        <span class="state-label">Horizontal · {{ variant }}</span>
+        <tds-divider orientation="horizontal" [variant]="variant"></tds-divider>
+      </div>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Vertical · all variants</span>
+      <div class="divider-vertical-row">
+        <ng-container *ngFor="let variant of dividerVariants">
+          <span>{{ variant }}</span>
+          <tds-divider orientation="vertical" [variant]="variant"></tds-divider>
+        </ng-container>
+      </div>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Defaults (no props)</span>
+      <tds-divider></tds-divider>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <section class="section" aria-labelledby="section-footer">
+    <h4 id="section-footer" class="tds-headline-03">Footer</h4>
+
+    <div class="state-row">
+      <span class="state-label">Full footer · mode-variant primary</span>
+      <tds-footer modeVariant="primary">
+        <div slot="top">
+          <tds-footer-group titleText="Pages">
+            <tds-footer-item><a href="/">Home</a></tds-footer-item>
+            <tds-footer-item><a href="/form">Form</a></tds-footer-item>
+            <tds-footer-item><a href="/table">Table</a></tds-footer-item>
+          </tds-footer-group>
+          <tds-footer-group titleText="Legal">
+            <tds-footer-item><a href="/">Terms & Conditions</a></tds-footer-item>
+            <tds-footer-item><a href="/">Privacy policy</a></tds-footer-item>
+          </tds-footer-group>
+          <tds-footer-group titleText="Design">
+            <tds-footer-item><a href="/">Grid</a></tds-footer-item>
+            <tds-footer-item><a href="/">Icons</a></tds-footer-item>
+            <tds-footer-item><a href="/">Tokens</a></tds-footer-item>
+          </tds-footer-group>
+        </div>
+        <div slot="start">
+          <tds-footer-group>
+            <tds-footer-item><a href="/">Link text</a></tds-footer-item>
+            <tds-footer-item><a href="/">Another link</a></tds-footer-item>
+          </tds-footer-group>
+        </div>
+        <div slot="end">
+          <tds-footer-group>
+            <tds-footer-item>
+              <a href="/"><tds-icon name="truck"></tds-icon></a>
+            </tds-footer-item>
+            <tds-footer-item>
+              <a href="/"><tds-icon name="truck"></tds-icon></a>
+            </tds-footer-item>
+          </tds-footer-group>
+        </div>
+      </tds-footer>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Full footer · mode-variant secondary</span>
+      <tds-footer modeVariant="secondary">
+        <div slot="top">
+          <tds-footer-group titleText="Pages">
+            <tds-footer-item><a href="/">Home</a></tds-footer-item>
+            <tds-footer-item><a href="/form">Form</a></tds-footer-item>
+          </tds-footer-group>
+          <tds-footer-group titleText="Legal">
+            <tds-footer-item><a href="/">Terms</a></tds-footer-item>
+            <tds-footer-item><a href="/">Privacy</a></tds-footer-item>
+          </tds-footer-group>
+        </div>
+        <div slot="start">
+          <tds-footer-group>
+            <tds-footer-item><a href="/">Link text</a></tds-footer-item>
+          </tds-footer-group>
+        </div>
+      </tds-footer>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Minimal · start slot only</span>
+      <tds-footer>
+        <div slot="start">
+          <tds-footer-group>
+            <tds-footer-item><a href="/">Single link</a></tds-footer-item>
+          </tds-footer-group>
+        </div>
+      </tds-footer>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Minimal · end slot only (icons)</span>
+      <tds-footer>
+        <div slot="end">
+          <tds-footer-group>
+            <tds-footer-item>
+              <a href="/"><tds-icon name="truck"></tds-icon></a>
+            </tds-footer-item>
+            <tds-footer-item>
+              <a href="/"><tds-icon name="truck"></tds-icon></a>
+            </tds-footer-item>
+          </tds-footer-group>
+        </div>
+      </tds-footer>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Top slot only · many groups (wrap)</span>
+      <tds-footer>
+        <div slot="top">
+          <tds-footer-group titleText="Group A">
+            <tds-footer-item><a href="/">Item A1</a></tds-footer-item>
+            <tds-footer-item><a href="/">Item A2</a></tds-footer-item>
+          </tds-footer-group>
+          <tds-footer-group titleText="Group B">
+            <tds-footer-item><a href="/">Item B1</a></tds-footer-item>
+            <tds-footer-item><a href="/">Item B2</a></tds-footer-item>
+          </tds-footer-group>
+          <tds-footer-group titleText="Group C">
+            <tds-footer-item><a href="/">Item C1</a></tds-footer-item>
+            <tds-footer-item><a href="/">Item C2</a></tds-footer-item>
+          </tds-footer-group>
+          <tds-footer-group titleText="Group D">
+            <tds-footer-item><a href="/">Item D1</a></tds-footer-item>
+            <tds-footer-item><a href="/">Item D2</a></tds-footer-item>
+          </tds-footer-group>
+          <tds-footer-group titleText="Group E">
+            <tds-footer-item><a href="/">Item E1</a></tds-footer-item>
+            <tds-footer-item><a href="/">Item E2</a></tds-footer-item>
+          </tds-footer-group>
+        </div>
+      </tds-footer>
+    </div>
+
+    <div class="state-row">
+      <span class="state-label">Empty footer (no slots)</span>
+      <tds-footer></tds-footer>
+    </div>
+  </section>
+</div>

--- a/src/app/pages/about-page/about-page.component.ts
+++ b/src/app/pages/about-page/about-page.component.ts
@@ -1,10 +1,38 @@
-import { Component } from "@angular/core";
+import { Component, OnDestroy, OnInit } from "@angular/core";
+import { CommonModule } from "@angular/common";
 import { TegelModule } from "@scania/tegel-angular-17";
+
+type Brand = "scania" | "traton";
 
 @Component({
   selector: "app-about-page",
   standalone: true,
   templateUrl: "./about-page.component.html",
-  imports: [TegelModule],
+  styleUrls: ["./about-page.component.css"],
+  imports: [TegelModule, CommonModule],
 })
-export default class AboutPageComponent {}
+export default class AboutPageComponent implements OnInit, OnDestroy {
+  brand: Brand = "scania";
+
+  dividerVariants: Array<
+    "discrete" | "subtle" | "soft" | "defined" | "dark-blue"
+  > = ["discrete", "subtle", "soft", "defined", "dark-blue"];
+
+  ngOnInit(): void {
+    this.applyBrand(this.brand);
+  }
+
+  ngOnDestroy(): void {
+    document.body.classList.remove("scania", "traton");
+  }
+
+  setBrand(brand: Brand): void {
+    this.brand = brand;
+    this.applyBrand(brand);
+  }
+
+  private applyBrand(brand: Brand): void {
+    document.body.classList.remove("scania", "traton");
+    document.body.classList.add(brand);
+  }
+}


### PR DESCRIPTION
## Summary
- Bumps `@scania/tegel-angular-17` to the beta `1.52.0-var-work-beta.0` so the variable-migration work can be exercised in the demo.
- Rebuilds the About page into a dedicated test surface for the four components touched by the migration — **Link**, **Breadcrumbs**, **Divider**, **Footer** — with multiple states per component so edge cases are visually verifiable.
- Adds a sticky brand toggle at the top of the About page that adds/removes `.scania` / `.traton` on `<body>`, so both brand variants can be flipped without a page reload.

## States covered
- **Link** — default inline, `underline`, `standalone`, `standalone + underline`, `disabled`, `disabled + standalone`, long-wrapping text, link with trailing icon.
- **Breadcrumbs** — single item (current only), two levels, default three levels, many levels with long label (overflow/wrap), no `current` flag.
- **Divider** — all 5 variants (`discrete`, `subtle`, `soft`, `defined`, `dark-blue`) in both `horizontal` and `vertical` orientations, plus defaults with no props.
- **Footer** — full footer with `modeVariant="primary"` and `"secondary"`, minimal start-only, minimal end-only (icons), top-only with many groups (wrap), and empty footer.

## Test plan
- [ ] Navigate to `/about`
- [ ] Toggle between Scania and Traton — confirm `body` class flips and components restyle
- [ ] Toggle light/dark and primary/secondary mode variants from the header switchers and re-verify each section
- [ ] Walk through each Link state in both brands
- [ ] Walk through each Breadcrumbs state in both brands
- [ ] Walk through each Divider variant × orientation in both brands
- [ ] Walk through each Footer slot configuration in both brands

🤖 Generated with [Claude Code](https://claude.com/claude-code)