### PR TITLE
chore: bump @scania/tegel-angular-17 to 1.55.0-var-batch-8-beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-angular-17": "1.55.0",
+        "@scania/tegel-angular-17": "1.55.0-var-batch-8-beta",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/angular-table": "^8.19.2",
         "ag-grid-angular": "^31.3.2",
@@ -4182,9 +4182,9 @@
       ]
     },
     "node_modules/@scania/tegel": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.55.0.tgz",
-      "integrity": "sha512-N4/wUsFTKWOV7qlLeBd3PEpz93ueiTlIxUpnnb3J1KgGB8zf5WPEdrVi/5cQCPRv7CmJ6oIXvlMufEEeK3G0QQ==",
+      "version": "1.55.0-var-batch-8-beta",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.55.0-var-batch-8-beta.tgz",
+      "integrity": "sha512-orlPngY7Eifs69nAdjoIOans3sOQAmDFAivWekE8VztnD8HBJ/QJgsh6xGHoKny47SJ61w2TAHUarvzRmeMqkg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4196,16 +4196,16 @@
       }
     },
     "node_modules/@scania/tegel-angular-17": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.55.0.tgz",
-      "integrity": "sha512-YrT97bgtEAkp2gcDvFYQ3lytTeOV1oxXO7Ut0CtHy9ULVqMjif3ayVbISEx3e/sfdYNfbZ2VLAy6Ys5agAv9BA==",
+      "version": "1.55.0-var-batch-8-beta",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.55.0-var-batch-8-beta.tgz",
+      "integrity": "sha512-g16pDdRKcb2TxND99CNPthaki3lFWPhey5Yy0+SC0WskO/Aqn7gEPd9cWCgolmQpvNeZJEnfL9hSmagT8DzSaA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">=17.0.0",
         "@angular/core": ">=17.0.0",
-        "@scania/tegel": "^1.55.0"
+        "@scania/tegel": "1.55.0-var-batch-8-beta"
       }
     },
     "node_modules/@scania/tegel-styles": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-angular-17": "1.55.0",
+    "@scania/tegel-angular-17": "1.55.0-var-batch-8-beta",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/angular-table": "^8.19.2",
     "ag-grid-angular": "^31.3.2",

--- a/src/app/pages/about-page/about-page.component.css
+++ b/src/app/pages/about-page/about-page.component.css
@@ -1,0 +1,61 @@
+.about {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 720px;
+  padding: 16px 0;
+}
+
+.about__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.about__header p {
+  margin: 0;
+  max-width: 60ch;
+}
+
+.component-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  border: 1px solid var(--tds-grey-300, #dadee4);
+  border-radius: 4px;
+  background: var(--tds-grey-50, #fafafa);
+}
+
+.component-section h4 {
+  margin: 0;
+}
+
+.about__note {
+  margin: 0;
+  color: var(--tds-grey-600, #6b7280);
+}
+
+.about__brand {
+  background: var(--tds-blue-50, #f0f3fb);
+}
+
+.demo-column {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.about__fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.about__fieldset legend {
+  padding: 0 0 8px;
+}
+
+.about code {
+  font-family: monospace;
+}

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -1,5 +1,65 @@
-<h3>About this page</h3>
-<p>
-  This page is a testing ground and demo for using &#64;scania/tegel-angular in
-  an Angular application.
-</p>
+<article class="about" [class.scania]="brand === 'scania'" [class.traton]="brand === 'traton'">
+  <header class="about__header">
+    <h3 class="tds-headline-02">Component test ground</h3>
+    <p class="tds-detail-02">
+      Testing <strong>&#64;scania/tegel-angular-17&#64;1.55.0-var-batch-8-beta</strong>:
+      checkbox, radio button and toggle. Flip the brand to confirm each component themes
+      correctly in Scania and Traton.
+    </p>
+  </header>
+
+  <section class="component-section about__brand">
+    <h4 class="tds-headline-06">Brand</h4>
+    <p class="about__note tds-detail-05">
+      Toggles the <code>.scania</code> / <code>.traton</code> theme class on the demo area below.
+    </p>
+    <tds-toggle [checked]="brand === 'traton'" (tdsToggle)="setBrand($event)">
+      <div slot="label">Brand: {{ brand === 'traton' ? 'Traton' : 'Scania' }}</div>
+    </tds-toggle>
+  </section>
+
+  <section class="component-section">
+    <h4 class="tds-headline-06">Checkbox</h4>
+    <p class="about__note tds-detail-05"><code>tds-checkbox</code> in its core states.</p>
+    <div class="demo-column">
+      <tds-checkbox><span slot="label">Default</span></tds-checkbox>
+      <tds-checkbox checked><span slot="label">Checked</span></tds-checkbox>
+      <tds-checkbox indeterminate><span slot="label">Indeterminate</span></tds-checkbox>
+      <tds-checkbox disabled><span slot="label">Disabled</span></tds-checkbox>
+      <tds-checkbox disabled checked><span slot="label">Disabled & checked</span></tds-checkbox>
+    </div>
+  </section>
+
+  <section class="component-section">
+    <h4 class="tds-headline-06">Radio button</h4>
+    <p class="about__note tds-detail-05"><code>tds-radio-button</code> as a single-select group.</p>
+    <fieldset class="demo-column about__fieldset">
+      <legend class="tds-detail-05">Choose a meal</legend>
+      @for (meal of meals; track meal.value) {
+        <tds-radio-button
+          name="meal"
+          [value]="meal.value"
+          [radioId]="'meal-' + meal.value"
+          [checked]="selectedMeal === meal.value"
+          (tdsChange)="selectedMeal = meal.value"
+        >
+          <span slot="label">{{ meal.label }}</span>
+        </tds-radio-button>
+      }
+      <tds-radio-button name="meal" value="soldout" radioId="meal-soldout" disabled>
+        <span slot="label">Sold out (disabled)</span>
+      </tds-radio-button>
+    </fieldset>
+  </section>
+
+  <section class="component-section">
+    <h4 class="tds-headline-06">Toggle</h4>
+    <p class="about__note tds-detail-05"><code>tds-toggle</code> in both sizes and states.</p>
+    <div class="demo-column">
+      <tds-toggle headline="Large"><div slot="label">Off by default</div></tds-toggle>
+      <tds-toggle headline="Large" checked><div slot="label">On by default</div></tds-toggle>
+      <tds-toggle size="sm" headline="Small"><div slot="label">Small size</div></tds-toggle>
+      <tds-toggle headline="Disabled" disabled><div slot="label">Disabled</div></tds-toggle>
+    </div>
+  </section>
+</article>

--- a/src/app/pages/about-page/about-page.component.ts
+++ b/src/app/pages/about-page/about-page.component.ts
@@ -1,10 +1,27 @@
 import { Component } from "@angular/core";
 import { TegelModule } from "@scania/tegel-angular-17";
 
+type Brand = "scania" | "traton";
+
 @Component({
   selector: "app-about-page",
   standalone: true,
   templateUrl: "./about-page.component.html",
+  styleUrl: "./about-page.component.css",
   imports: [TegelModule],
 })
-export default class AboutPageComponent {}
+export default class AboutPageComponent {
+  brand: Brand = "scania";
+  selectedMeal = "salmon";
+
+  meals = [
+    { value: "salmon", label: "Salmon" },
+    { value: "veal", label: "Veal" },
+    { value: "chicken", label: "Chicken" },
+  ];
+
+  setBrand(event: Event) {
+    const { checked } = (event as CustomEvent<{ toggleId: string; checked: boolean }>).detail;
+    this.brand = checked ? "traton" : "scania";
+  }
+}


### PR DESCRIPTION
## Summary

- Bump `@scania/tegel-angular-17` to `1.55.0-var-batch-8-beta`.
- Rework the About page into a component test ground for **checkbox, radio button and toggle**.
- Add a Scania/Traton **brand toggle** that themes the demo area so the components can be verified in both brands.

## Components covered

`tds-checkbox` (default / checked / indeterminate / disabled), `tds-radio-button` (single-select group + disabled), `tds-toggle` (large / small / checked / disabled).

## Test plan

- [ ] `npm install` runs clean
- [ ] `ng build` succeeds (verified locally, exit 0)
- [ ] About page renders without console errors
- [ ] Brand toggle flips `.scania` / `.traton` and re-themes all three components
- [ ] Checkbox states render correctly
- [ ] Radio group is single-select; disabled option not selectable
- [ ] Toggle switches and disabled toggle is inert

🤖 Generated with [Claude Code](https://claude.com/claude-code)