### PR TITLE
chore: bump @scania/tegel-angular-17 to 1.55.0-var-batch-8-beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-angular-17": "1.55.0",
+        "@scania/tegel-angular-17": "1.55.0-var-batch-8-beta",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/angular-table": "^8.19.2",
         "ag-grid-angular": "^31.3.2",
@@ -4182,9 +4182,9 @@
       ]
     },
     "node_modules/@scania/tegel": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.55.0.tgz",
-      "integrity": "sha512-N4/wUsFTKWOV7qlLeBd3PEpz93ueiTlIxUpnnb3J1KgGB8zf5WPEdrVi/5cQCPRv7CmJ6oIXvlMufEEeK3G0QQ==",
+      "version": "1.55.0-var-batch-8-beta",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.55.0-var-batch-8-beta.tgz",
+      "integrity": "sha512-orlPngY7Eifs69nAdjoIOans3sOQAmDFAivWekE8VztnD8HBJ/QJgsh6xGHoKny47SJ61w2TAHUarvzRmeMqkg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4196,16 +4196,16 @@
       }
     },
     "node_modules/@scania/tegel-angular-17": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.55.0.tgz",
-      "integrity": "sha512-YrT97bgtEAkp2gcDvFYQ3lytTeOV1oxXO7Ut0CtHy9ULVqMjif3ayVbISEx3e/sfdYNfbZ2VLAy6Ys5agAv9BA==",
+      "version": "1.55.0-var-batch-8-beta",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.55.0-var-batch-8-beta.tgz",
+      "integrity": "sha512-g16pDdRKcb2TxND99CNPthaki3lFWPhey5Yy0+SC0WskO/Aqn7gEPd9cWCgolmQpvNeZJEnfL9hSmagT8DzSaA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">=17.0.0",
         "@angular/core": ">=17.0.0",
-        "@scania/tegel": "^1.55.0"
+        "@scania/tegel": "1.55.0-var-batch-8-beta"
       }
     },
     "node_modules/@scania/tegel-styles": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-angular-17": "1.55.0",
+    "@scania/tegel-angular-17": "1.55.0-var-batch-8-beta",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/angular-table": "^8.19.2",
     "ag-grid-angular": "^31.3.2",


### PR DESCRIPTION
## Summary

- Bump `@scania/tegel-angular-17` to `1.55.0-var-batch-8-beta`. Version bump only.

## Test plan

- [ ] `npm install` runs clean
- [ ] dev server boots; app renders without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)