### PR TITLE
chore: bump @scania/tegel-angular-17 to 1.58.0-memory-fix-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-angular-17": "1.58.0",
+        "@scania/tegel-angular-17": "1.58.0-memory-fix-beta.0",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/angular-table": "^8.19.2",
         "ag-grid-angular": "^31.3.2",
@@ -4182,9 +4182,9 @@
       ]
     },
     "node_modules/@scania/tegel": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.58.0.tgz",
-      "integrity": "sha512-bBH7bLIZew/bWZL/7JSZksta2ingEPaWJTkQTA2vR+gfAEIub2zXk03TjhAzNUWq8g6VofubBVbiKkmzObcuGQ==",
+      "version": "1.58.0-memory-fix-beta.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.58.0-memory-fix-beta.0.tgz",
+      "integrity": "sha512-ZV9yTAjwdzyDZbiIYMa45EuC7cAv+PVKY2co/HorYnRZxLKe5xGEpU28jslcfN/jGZ/LkTn1/6ffreRKI6FSHg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4196,16 +4196,16 @@
       }
     },
     "node_modules/@scania/tegel-angular-17": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.58.0.tgz",
-      "integrity": "sha512-0FnRFH3OWjdIQxolXOCb4bJpv1aCNQd5Iq/eBpAU2tHY4buX8Chdzi6AjVlJO/wf+QQM30ITaUFOJCm/V1qKRA==",
+      "version": "1.58.0-memory-fix-beta.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular-17/-/tegel-angular-17-1.58.0-memory-fix-beta.0.tgz",
+      "integrity": "sha512-3ytB4TT9kcVWN+USq3ojHouqe7sVpTz+cv49nnIHxVVK2Ca9bqMm6IXIJisk9X5riN/gF7cFmuf0k+PbkavzpQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">=17.0.0",
         "@angular/core": ">=17.0.0",
-        "@scania/tegel": "^1.58.0"
+        "@scania/tegel": "1.58.0-memory-fix-beta.0"
       }
     },
     "node_modules/@scania/tegel-styles": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-angular-17": "1.58.0",
+    "@scania/tegel-angular-17": "1.58.0-memory-fix-beta.0",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/angular-table": "^8.19.2",
     "ag-grid-angular": "^31.3.2",


### PR DESCRIPTION
## Summary

- Bump `@scania/tegel-angular-17` to `1.58.0-memory-fix-beta.0` (memory-fix beta).
- Dependency bump only — no source or About-page changes.
- Branched off `main` (no `develop` branch exists on this repo).

## Validation

- `ng build --configuration development` passed locally.

## Test plan

- [ ] `npm install` runs clean
- [ ] dev server boots
- [ ] App renders without console errors